### PR TITLE
Cambios en la plantilla de correo de recuperación de contraseña

### DIFF
--- a/Backend/HireAProBackend/Controllers/Controlador.cs
+++ b/Backend/HireAProBackend/Controllers/Controlador.cs
@@ -201,7 +201,8 @@ namespace HireAProBackend.Controllers
                             username = registerRequest.Username,
                             email = registerRequest.Email,
                             password = hashedPassword, // lo que se enviará será la contraseña hasheada anteriormente
-                            verified = false
+                            verified = false,
+                            createdAt = DateTime.UtcNow
                         });
 
                         _emailService.SendEmail(verifyEmail);
@@ -493,7 +494,7 @@ namespace HireAProBackend.Controllers
                     // TODO configurar el endpoint o una variable que alojará el valor de tokenRecupoeracion como query por Get
                     string link = "http://localhost:4200/login/forgot-password?t=" + tokenRecuperacion;
                     await guardarToken(tokenRecuperacion, email); // envia el token a la base de datos en la coleccion "tokens"
-                    string body = emailContent.PassBody(email, link);
+                    string body = emailContent.PassBody(usuario.Username, link); 
 
                     emailRequest.Body = body;
                     

--- a/Backend/HireAProBackend/Models/Usuario.cs
+++ b/Backend/HireAProBackend/Models/Usuario.cs
@@ -18,6 +18,9 @@ namespace HireAProBackend.Models
         [FirestoreProperty("verified")]
         public bool Verified { get; set; }
 
+        [FirestoreProperty("createdAt")]
+        public DateTime CreatedAt { get; set; }
+
         public Usuario() { }
 
      

--- a/Backend/HireAProBackend/Templates/EmailContent.cs
+++ b/Backend/HireAProBackend/Templates/EmailContent.cs
@@ -150,7 +150,7 @@
                     </tr>
                     <tr>
                         <td style='padding:40px 30px 0px 30px; text-align:center; color:#2f2f2f;'>
-                            <h1>" + user + @" Has solicitado regenerar tu contrase&ntilde;a</h1>
+                            <h1>" + user + @"<br>Has solicitado regenerar tu contrase&ntilde;a</h1>
                         </td>
                     </tr>
                     <tr>


### PR DESCRIPTION
- Envía el nombre de usuario en el correo de recuperación de contraseña en vez del email del usuario